### PR TITLE
feat(quotes): allow template literals

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = {
     "import",
   ],
   "rules": {
-    "quotes": [2, "single", "avoid-escape"],
+    "quotes": [2, "single", {"avoidEscape": true, "allowTemplateLiterals": true}],
     "no-use-before-define": [2, "nofunc"],
     "no-unused-expressions": 0,
     "strict": 0,

--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "eslint-plugin-import": "1.4.0"
   },
   "peerDependencies": {
-    "eslint": "^2.0.0"
+    "eslint": "^2.8.0"
   },
   "devDependencies": {
     "babel-eslint": "6.0.2",
     "commitizen": "2.7.2",
     "cz-conventional-changelog": "1.1.5",
-    "eslint": "2.4.0",
+    "eslint": "2.8.0",
     "eslint-find-new-rules": "1.0.0",
     "eslint-import-resolver-webpack": "0.2.0",
     "eslint-plugin-react": "4.2.3",


### PR DESCRIPTION
eslint@2.8.0 has new options for quotes which allow the use of template literals alongside the other
types of quotes. As this change requires a specific version of eslint I bumped the peerDependancy
too