### PR TITLE
Fix ESLint 5.0 deprecation

### DIFF
--- a/es6/non-rules-config.js
+++ b/es6/non-rules-config.js
@@ -4,9 +4,8 @@ module.exports = {
     es6: true,
   },
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2018,
     sourceType: 'module',
-    ecmaFeatures: {experimentalObjectRestSpread: true},
   },
   plugins: [
     'babel',

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "webpack": "^3.7.1"
   },
   "peerDependencies": {
-    "eslint": ">=3"
+    "eslint": ">=5"
   },
   "devDependencies": {
     "eslint": "^4.8.0",


### PR DESCRIPTION
Currently, this config breaks with ESLint 5.0. I've fixed the issue. Read more about the deprecation [here](https://eslint.org/docs/user-guide/migrating-to-5.0.0#experimental-object-rest-spread).