### PR TITLE
Update `eslint-plugin-jest` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-import-resolver-webpack": "^0.10.1",
     "eslint-plugin-babel": "^5.1.0",
     "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-jest": "^21.2.0",
+    "eslint-plugin-jest": "^21.22.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.4.0",
     "webpack": "^4.12.1"


### PR DESCRIPTION
lower version does not have the rule of 'jest/no-jest-import', which is included in the './jest.js'