### PR TITLE
feat(rules): add new rules for jest & update eslint-plugin-jest

### DIFF
--- a/jest.js
+++ b/jest.js
@@ -27,6 +27,8 @@ module.exports = {
     'jest/prefer-inline-snapshots': 'off',
     'jest/prefer-strict-equal': 'off',
     'jest/prefer-spy-on': 'off',
+    'jest/prefer-todo': 'warn',
+    'jest/no-truthy-falsy': 'warn',
   },
   env: {
     'jest/globals': true,

--- a/jest.js
+++ b/jest.js
@@ -28,7 +28,7 @@ module.exports = {
     'jest/prefer-strict-equal': 'off',
     'jest/prefer-spy-on': 'off',
     'jest/prefer-todo': 'warn',
-    'jest/no-truthy-falsy': 'warn',
+    'jest/no-truthy-falsy': 'off',
   },
   env: {
     'jest/globals': true,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-import-resolver-webpack": "^0.10.1",
     "eslint-plugin-babel": "^5.2.0",
     "eslint-plugin-import": "^2.16.0",
-    "eslint-plugin-jest": "^21.22.0",
+    "eslint-plugin-jest": "^22.2.2",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.11.1",
     "read-pkg-up": "^4.0.0",


### PR DESCRIPTION
Jest added new feature for test.todo from Jest 24, it should be prefered
over test.skip

Rule:
jest/prefer-todo
https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/prefer-todo.md

Resoning:
https://jestjs.io/blog/2019/01/25/jest-24-refreshing-polished-typescript-friendly#testtodo

Rule:
jest/no-truthy-falsy
https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-truthy-falsy.md

Resoning:
https://github.com/jest-community/eslint-plugin-jest/issues/204
https://vincenttunru.com/toBeTruthy-vs-toBe-true/