### PR TITLE
refactor: Extract deprecated babel rules into it's own file

### DIFF
--- a/es6/best-practices.js
+++ b/es6/best-practices.js
@@ -20,9 +20,5 @@ module.exports = {
     'prefer-template': 'error',
     'require-yield': 'error',
     'symbol-description': 'error',
-
-    // babel plugin
-    //   no eslint version
-    'babel/no-await-in-loop': 'off', // this is deprecated
   },
 }

--- a/es6/deprecated-rules.js
+++ b/es6/deprecated-rules.js
@@ -1,0 +1,12 @@
+module.exports = {
+  extends: './non-rules-config.js',
+  rules: {
+    'babel/array-bracket-spacing': 'off',
+    'babel/arrow-parens': 'off',
+    'babel/flow-object-type': 'off',
+    'babel/func-params-comma-dangle': 'off',
+    'babel/generator-star-spacing': 'off',
+    'babel/no-await-in-loop': 'off',
+    'babel/object-shorthand': 'off',
+  },
+}

--- a/es6/index.js
+++ b/es6/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   extends: [
     './non-rules-config.js',
+    './deprecated-rules.js',
     './stylistic.js',
     './best-practices.js',
     './possible-errors.js',

--- a/es6/stylistic.js
+++ b/es6/stylistic.js
@@ -27,15 +27,5 @@ module.exports = {
 
     'valid-typeof': 'off',
     'babel/valid-typeof': 'error',
-
-    //   no eslint version
-    'babel/flow-object-type': 'off', // no opinion
-
-    // deprecated rules
-    'babel/array-bracket-spacing': 'off',
-    'babel/arrow-parens': 'off',
-    'babel/func-params-comma-dangle': 'off',
-    'babel/generator-star-spacing': 'off',
-    'babel/object-shorthand': 'off',
   },
 }


### PR DESCRIPTION
https://github.com/babel/eslint-plugin-babel#deprecated