### PR TITLE
feat: Support TypeScript linting

### DIFF
--- a/best-practices.js
+++ b/best-practices.js
@@ -98,4 +98,60 @@ module.exports = {
       },
     ],
   },
+  overrides: [
+    {
+      files: ['**/*.ts?(x)'],
+      rules: {
+        'default-param-last': 'off',
+        '@typescript-eslint/default-param-last': 'off',
+
+        'dot-notation': 'off',
+        '@typescript-eslint/dot-notation': 'error',
+
+        'no-empty-function': 'off',
+        '@typescript-eslint/no-empty-function': 'off',
+
+        'no-implied-eval': 'error',
+        '@typescript-eslint/no-implied-eval': 'error',
+
+        'no-invalid-this': 'off',
+        '@typescript-eslint/no-invalid-this': 'error',
+
+        'no-loop-func': 'off',
+        '@typescript-eslint/no-loop-func': 'error',
+
+        'no-magic-numbers': 'off',
+        '@typescript-eslint/no-magic-numbers': 'off',
+
+        'no-redeclare': 'off',
+        '@typescript-eslint/no-redeclare': 'error',
+
+        'no-return-await': 'off',
+        '@typescript-eslint/return-await': 'error',
+
+        'no-shadow': 'off',
+        '@typescript-eslint/no-shadow': 'error',
+
+        'no-throw-literal': 'off',
+        '@typescript-eslint/no-throw-literal': 'error',
+
+        'no-unused-expressions': 'off',
+        '@typescript-eslint/no-unused-expressions': 'off',
+
+        'no-unused-vars': 'off',
+        '@typescript-eslint/no-unused-vars': [
+          'error',
+          {
+            argsIgnorePattern: '^_',
+            varsIgnorePattern: '^ignored',
+            args: 'after-used',
+            ignoreRestSiblings: true,
+          },
+        ],
+
+        'require-await': 'off',
+        '@typescript-eslint/require-await': 'error',
+      },
+    },
+  ],
 }

--- a/best-practices.js
+++ b/best-practices.js
@@ -102,6 +102,8 @@ module.exports = {
     {
       files: ['**/*.ts?(x)'],
       rules: {
+        'no-undef': 'off', // ts(2304)
+
         'default-param-last': 'off',
         '@typescript-eslint/default-param-last': 'off',
 
@@ -124,7 +126,7 @@ module.exports = {
         '@typescript-eslint/no-magic-numbers': 'off',
 
         'no-redeclare': 'off',
-        '@typescript-eslint/no-redeclare': 'error',
+        '@typescript-eslint/no-redeclare': 'off', // ts(2451)
 
         'no-return-await': 'off',
         '@typescript-eslint/return-await': 'error',

--- a/best-practices.js
+++ b/best-practices.js
@@ -153,6 +153,59 @@ module.exports = {
 
         'require-await': 'off',
         '@typescript-eslint/require-await': 'error',
+
+        '@typescript-eslint/array-type': 'off',
+        '@typescript-eslint/await-thenable': 'error',
+        '@typescript-eslint/ban-ts-comment': 'error',
+        '@typescript-eslint/ban-types': 'off', // not useful in a reusable config
+        '@typescript-eslint/class-literal-property-style': 'off',
+        '@typescript-eslint/consistent-type-assertions': 'off',
+        '@typescript-eslint/no-base-to-string': 'warn',
+        '@typescript-eslint/no-confusing-void-expression': 'off', // honestly, it's probably a good rule, but I do this all the time so...
+        '@typescript-eslint/no-dynamic-delete': 'error',
+        '@typescript-eslint/no-empty-interface': 'error',
+        '@typescript-eslint/no-explicit-any': 'error',
+        '@typescript-eslint/no-extraneous-class': 'error', // stay away from classes when you can
+        '@typescript-eslint/no-floating-promises': 'warn', // not a bad rule, but can be annoying
+        '@typescript-eslint/no-for-in-array': 'error',
+        '@typescript-eslint/no-implicit-any-catch': 'warn',
+        '@typescript-eslint/no-inferrable-types': 'off', // I personally prefer relying on inference where possible, but I don't want to lint for it.
+        '@typescript-eslint/no-invalid-void-type': 'warn',
+        '@typescript-eslint/no-misused-new': 'error',
+        '@typescript-eslint/no-misused-promises': 'warn',
+        '@typescript-eslint/no-namespace': 'error',
+        '@typescript-eslint/no-require-imports': 'off', // sometimes you can't do it any other way
+        '@typescript-eslint/no-this-alias': 'error',
+        '@typescript-eslint/no-unnecessary-condition': 'error',
+        '@typescript-eslint/no-unnecessary-qualifier': 'warn', // I'm not sure I understand this one
+        '@typescript-eslint/no-unnecessary-type-arguments': 'off',
+        '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+        '@typescript-eslint/no-unnecessary-type-constraint': 'error',
+        '@typescript-eslint/no-var-requires': 'error',
+        '@typescript-eslint/prefer-as-const': 'error',
+        '@typescript-eslint/prefer-enum-initializers': 'error', // makes total sense
+        '@typescript-eslint/prefer-function-type': 'off', // though I'm not sure I understand it
+        '@typescript-eslint/prefer-includes': 'error', // normally I wouldn't but includes is just so much better
+        '@typescript-eslint/prefer-literal-enum-member': 'error',
+        '@typescript-eslint/prefer-namespace-keyword': 'error',
+        '@typescript-eslint/prefer-nullish-coalescing': 'error',
+        '@typescript-eslint/prefer-optional-chain': 'error',
+        '@typescript-eslint/prefer-readonly': 'off',
+        '@typescript-eslint/prefer-reduce-type-parameter': 'warn',
+        '@typescript-eslint/prefer-regexp-exec': 'error',
+        '@typescript-eslint/prefer-string-starts-ends-with': 'error',
+        '@typescript-eslint/prefer-ts-expect-error': 'error',
+        '@typescript-eslint/promise-function-async': 'off',
+        '@typescript-eslint/require-array-sort-compare': 'off',
+        '@typescript-eslint/restrict-plus-operands': 'error',
+        '@typescript-eslint/restrict-template-expressions': 'error',
+        '@typescript-eslint/strict-boolean-expressions': 'off',
+        '@typescript-eslint/switch-exhaustiveness-check': 'error',
+        '@typescript-eslint/triple-slash-reference': 'error',
+        '@typescript-eslint/unbound-method': 'error',
+
+        //  variables
+        '@typescript-eslint/unified-signatures': 'warn',
       },
     },
   ],

--- a/es6/best-practices.js
+++ b/es6/best-practices.js
@@ -17,4 +17,16 @@ module.exports = {
     'require-yield': 'error',
     'symbol-description': 'error',
   },
+  overrides: [
+    {
+      files: ['**/*.ts?(x)'],
+      rules: {
+        'no-duplicate-imports': 'error',
+        '@typescript-eslint/no-duplicate-imports': 'error',
+
+        'no-useless-constructor': 'off',
+        '@typescript-eslint/no-useless-constructor': 'error',
+      },
+    },
+  ],
 }

--- a/es6/best-practices.js
+++ b/es6/best-practices.js
@@ -21,6 +21,11 @@ module.exports = {
     {
       files: ['**/*.ts?(x)'],
       rules: {
+        'no-var': 'error', // ts transpiles let/const to var, so no need for vars any more
+        'prefer-const': 'error', // ts provides better types with const
+        'prefer-rest-params': 'error', // ts provides better types with rest args over arguments
+        'prefer-spread': 'error', // ts transpiles spread to apply, so no need for manual apply
+
         'no-duplicate-imports': 'error',
         '@typescript-eslint/no-duplicate-imports': 'error',
 

--- a/es6/non-rules-config.js
+++ b/es6/non-rules-config.js
@@ -9,4 +9,16 @@ module.exports = {
     sourceType: 'module',
   },
   plugins: ['babel'],
+  overrides: [
+    {
+      files: ['**/*.ts?(x)'],
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        ecmaVersion: 2018,
+        sourceType: 'module',
+      },
+      plugins: ['@typescript-eslint'],
+      rules: {},
+    },
+  ],
 }

--- a/es6/possible-errors.js
+++ b/es6/possible-errors.js
@@ -17,8 +17,14 @@ module.exports = {
     {
       files: ['**/*.ts?(x)'],
       rules: {
+        'constructor-super': 'off', // ts(2335) & ts(2377)
+        'no-const-assign': 'off', // ts(2588)
+        'no-new-symbol': 'off', // ts(2588)
+        'no-this-before-super': 'off', // ts(2376)
+        'babel/valid-typeof': 'off', // ts(2367)
+
         'no-dupe-class-members': 'off',
-        '@typescript-eslint/no-dupe-class-members': 'error',
+        '@typescript-eslint/no-dupe-class-members': 'off', // ts(2393) & ts(2300)
 
         'babel/no-unused-expressions': 'off',
         '@typescript-eslint/no-unused-expressions': 'error',

--- a/es6/possible-errors.js
+++ b/es6/possible-errors.js
@@ -9,7 +9,20 @@ module.exports = {
 
     'no-unused-expressions': 'off',
     'babel/no-unused-expressions': 'error',
+
     'valid-typeof': 'off',
     'babel/valid-typeof': 'error',
   },
+  overrides: [
+    {
+      files: ['**/*.ts?(x)'],
+      rules: {
+        'no-dupe-class-members': 'off',
+        '@typescript-eslint/no-dupe-class-members': 'error',
+
+        'babel/no-unused-expressions': 'off',
+        '@typescript-eslint/no-unused-expressions': 'error',
+      },
+    },
+  ],
 }

--- a/es6/stylistic.js
+++ b/es6/stylistic.js
@@ -11,6 +11,7 @@ module.exports = {
 
     camelcase: 'off',
     'babel/camelcase': ['error', {properties: 'always'}],
+
     'new-cap': 'off',
     'babel/new-cap': [
       'error',
@@ -19,7 +20,21 @@ module.exports = {
         capIsNew: true,
       },
     ],
+
     'no-invalid-this': 'off',
     'babel/no-invalid-this': 'error',
   },
+  overrides: [
+    {
+      files: ['**/*.ts?(x)'],
+      extends: 'prettier/@typescript-eslint',
+      rules: {
+        'babel/camelcase': 'off',
+        '@typescript-eslint/camelcase': ['error', {properties: 'always'}],
+
+        'babel/no-invalid-this': 'off',
+        '@typescript-eslint/no-invalid-this': 'error',
+      },
+    },
+  ],
 }

--- a/import/non-rules-config.js
+++ b/import/non-rules-config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  plugins: ['import'],
   env: {
     es6: true,
   },
@@ -7,7 +6,21 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'module',
   },
+  plugins: ['import'],
   settings: {
     'import/ignore': ['node_modules', '.json$', '.(scss|less|css|styl)$'],
   },
+  overrides: [
+    {
+      files: ['**/*.ts?(x)'],
+      extends: 'plugin:import/typescript',
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        ecmaVersion: 2018,
+        sourceType: 'module',
+      },
+      plugins: ['@typescript-eslint'],
+      rules: {},
+    },
+  ],
 }

--- a/non-rules-config.js
+++ b/non-rules-config.js
@@ -4,4 +4,16 @@ module.exports = {
     node: true,
   },
   rules: {},
+  overrides: [
+    {
+      files: ['**/*.ts?(x)'],
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        ecmaVersion: 2018,
+        sourceType: 'module',
+      },
+      plugins: ['@typescript-eslint'],
+      rules: {},
+    },
+  ],
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
   },
   "homepage": "https://github.com/kentcdodds/eslint-config-kentcdodds#readme",
   "dependencies": {
+    "@typescript-eslint/eslint-plugin": "^4.7.0",
+    "@typescript-eslint/parser": "^4.7.0",
     "babel-eslint": "^10.1.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-import-resolver-webpack": "^0.13.0",
@@ -48,19 +50,26 @@
     "semver": "^7.3.2",
     "webpack": "^5.4.0"
   },
-  "peerDependencies": {
-    "eslint": "^7.0.0"
-  },
   "devDependencies": {
     "@testing-library/dom": "^7.26.5",
     "@testing-library/jest-dom": "^5.11.5",
-    "eslint": "^7.12.0",
+    "eslint": "^7.13.0",
     "eslint-find-rules": "^3.6.1",
     "husky": "^4.3.0",
     "jest": "^26.6.3",
     "npm-run-all": "^4.1.5",
     "prettier": "2.1.2",
-    "pretty-quick": "^3.1.0"
+    "pretty-quick": "^3.1.0",
+    "typescript": "^4.0.5"
+  },
+  "peerDependencies": {
+    "eslint": "^7.5.0",
+    "typescript": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "eslintConfig": {
     "extends": "./index.js"

--- a/possible-errors.js
+++ b/possible-errors.js
@@ -65,6 +65,13 @@ module.exports = {
 
         'no-use-before-define': 'off',
         '@typescript-eslint/no-use-before-define': ['error', 'nofunc'],
+
+        '@typescript-eslint/no-non-null-asserted-optional-chain': 'error',
+        '@typescript-eslint/no-unsafe-assignment': 'warn', // seems like an ok idea, but I don't have enough experience with TS yet.
+        '@typescript-eslint/no-unsafe-call': 'warn', // seems like an ok idea, but I don't have enough experience with TS yet.
+        '@typescript-eslint/no-unsafe-member-access': 'warn', // seems like an ok idea, but I don't have enough experience with TS yet.
+        '@typescript-eslint/no-unsafe-return': 'warn', // seems like an ok idea, but I don't have enough experience with TS yet.
+        '@typescript-eslint/prefer-readonly-parameter-types': 'off',
       },
     },
   ],

--- a/possible-errors.js
+++ b/possible-errors.js
@@ -45,4 +45,16 @@ module.exports = {
     // variables
     'no-use-before-define': ['error', 'nofunc'],
   },
+  overrides: [
+    {
+      files: ['**/*.ts?(x)'],
+      rules: {
+        'no-loss-of-precision': 'off',
+        '@typescript-eslint/no-loss-of-precision': 'error',
+
+        'no-use-before-define': 'off',
+        '@typescript-eslint/no-use-before-define': ['error', 'nofunc'],
+      },
+    },
+  ],
 }

--- a/possible-errors.js
+++ b/possible-errors.js
@@ -49,6 +49,17 @@ module.exports = {
     {
       files: ['**/*.ts?(x)'],
       rules: {
+        'getter-return': 'off', // ts(2378)
+        'no-dupe-args': 'off', // ts(2300)
+        'no-dupe-keys': 'off', // ts(1117)
+        'no-func-assign': 'off', // ts(2539)
+        'no-import-assign': 'off', // ts(2539) & ts(2540)
+        'no-obj-calls': 'off', // ts(2349)
+        'no-setter-return': 'off', // ts(2408)
+        'no-unreachable': 'off', // ts(7027)
+        'no-unsafe-negation': 'off', // ts(2365) & ts(2360) & ts(2358)
+        'valid-typeof': 'off', // ts(2367)
+
         'no-loss-of-precision': 'off',
         '@typescript-eslint/no-loss-of-precision': 'error',
 

--- a/react.js
+++ b/react.js
@@ -118,4 +118,16 @@ module.exports = {
     'react-hooks/exhaustive-deps': 'warn',
     'react-hooks/rules-of-hooks': 'error',
   },
+  overrides: [
+    {
+      files: ['**/*.ts?(x)'],
+      rules: {
+        'react/jsx-filename-extension': [
+          'error',
+          {extensions: ['.ts', '.tsx']},
+        ],
+        'react/prop-types': 'off',
+      },
+    },
+  ],
 }

--- a/stylistic.js
+++ b/stylistic.js
@@ -69,6 +69,28 @@ module.exports = {
         // variables
         'init-declarations': 'off',
         '@typescript-eslint/init-declarations': 'off',
+
+        '@typescript-eslint/adjacent-overload-signatures': 'error',
+        '@typescript-eslint/ban-tslint-comment': 'error',
+        '@typescript-eslint/consistent-indexed-object-style': 'off',
+        '@typescript-eslint/consistent-type-definitions': 'off',
+        '@typescript-eslint/consistent-type-imports': 'off', // I think I prefer typed imports, but you can't always use them
+        '@typescript-eslint/explicit-function-return-type': 'off',
+        '@typescript-eslint/explicit-module-boundary-types': 'off',
+        '@typescript-eslint/member-delimiter-style': 'off',
+        '@typescript-eslint/member-ordering': 'off',
+        '@typescript-eslint/method-signature-style': 'off',
+        '@typescript-eslint/no-confusing-non-null-assertion': 'off', // prettier reformats their "correct" example anyway 🤷‍♂️
+        '@typescript-eslint/no-extra-non-null-assertion': 'error',
+        '@typescript-eslint/no-non-null-assertion': 'error',
+        '@typescript-eslint/no-parameter-properties': 'error', // yeah, I don't like this feature
+        '@typescript-eslint/no-type-alias': 'off',
+        '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'warn',
+        '@typescript-eslint/prefer-for-of': 'off', // I prefer for of, but I don't want to lint for it
+        '@typescript-eslint/typedef': 'off',
+
+        //  variables
+        '@typescript-eslint/naming-convention': 'off',
       },
     },
   ],

--- a/stylistic.js
+++ b/stylistic.js
@@ -88,8 +88,6 @@ module.exports = {
         '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'warn',
         '@typescript-eslint/prefer-for-of': 'off', // I prefer for of, but I don't want to lint for it
         '@typescript-eslint/typedef': 'off',
-
-        //  variables
         '@typescript-eslint/naming-convention': 'off',
       },
     },

--- a/stylistic.js
+++ b/stylistic.js
@@ -55,4 +55,21 @@ module.exports = {
     // variables
     'init-declarations': 'off',
   },
+  overrides: [
+    {
+      files: ['**/*.ts?(x)'],
+      extends: 'prettier/@typescript-eslint',
+      rules: {
+        'lines-between-class-members': 'off',
+        '@typescript-eslint/lines-between-class-members': 'off',
+
+        'no-array-constructor': 'off',
+        '@typescript-eslint/no-array-constructor': 'error',
+
+        // variables
+        'init-declarations': 'off',
+        '@typescript-eslint/init-declarations': 'off',
+      },
+    },
+  ],
 }


### PR DESCRIPTION
- Enable TypeScript linting
- Override rules with @typescript-eslint rules for ts(x) files (https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin#extension-rules)
- Turn off rules that are handled by TypeScript (https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/src/configs/eslint-recommended.ts)
- Add TypeScript rules for React
- Add all @typescript-eslint [Supported Rules](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/README.md#supported-rules)

---

BREAKING CHANGE: Requires ESLint@^7.5.x
BREAKING CHANGE: (Optionally) requires TypeScript@^4.x

Closes #47