### PR TITLE
refactor: Remove all Prettier rules

### DIFF
--- a/best-practices.js
+++ b/best-practices.js
@@ -28,7 +28,6 @@ module.exports = {
     'no-extra-bind': 'error',
     'no-extra-label': 'error',
     'no-fallthrough': 'error',
-    'no-floating-decimal': 'error',
     'no-global-assign': 'error',
     'no-implicit-coercion': 'off',
     'no-implicit-globals': 'error',

--- a/es6/stylistic.js
+++ b/es6/stylistic.js
@@ -1,7 +1,6 @@
 module.exports = {
   extends: './non-rules-config.js',
   rules: {
-    'arrow-body-style': 'off', // this is nice, but not useful all the time.
     'object-shorthand': ['error', 'properties'], // methods are optional so you can specify a name if you want
     'prefer-arrow-callback': [
       'error',

--- a/possible-errors.js
+++ b/possible-errors.js
@@ -31,7 +31,6 @@ module.exports = {
     'no-setter-return': 'error',
     'no-sparse-arrays': 'error',
     'no-template-curly-in-string': 'error',
-    'no-unexpected-multiline': 'error',
     'no-unreachable': 'error',
     'no-unsafe-finally': 'error',
     'no-unsafe-negation': 'error',

--- a/react.js
+++ b/react.js
@@ -97,7 +97,6 @@ module.exports = {
     'react/style-prop-object': 'error',
     'react/void-dom-elements-no-children': 'error',
     'react/default-props-match-prop-types': 'error',
-    'react/jsx-child-element-spacing': 'warn',
     'react/jsx-curly-brace-presence': [
       'warn',
       {props: 'never', children: 'ignore'},
@@ -113,7 +112,6 @@ module.exports = {
     'react/destructuring-assignment': 'off',
     'react/forbid-dom-props': 'off',
     'react/jsx-max-depth': 'off',
-    'react/jsx-props-no-multi-spaces': 'off',
     'react/jsx-sort-default-props': 'off',
     'react/jsx-no-useless-fragment': 'warn',
 

--- a/stylistic.js
+++ b/stylistic.js
@@ -15,8 +15,6 @@ module.exports = {
       '^\\$?(__)?(([A-Z]|[a-z]|[0-9]+)|([A-Z_]))*\\$?$',
     ],
     'line-comment-position': 'off',
-    'linebreak-style': ['error', 'unix'],
-    'lines-around-comment': 'off',
     'lines-between-class-members': 'off',
     'max-depth': ['error', 4],
     'max-lines': [


### PR DESCRIPTION
Since Prettier is run after all other ES6 rules, we can just remove all rules
https://github.com/kentcdodds/eslint-config-kentcdodds/blob/b903f611aed6ad6cec46ec88d592319802ee6da6/es6/index.js#L2-L9

Used prettier ESLint configs:
- [`prettier`](https://github.com/prettier/eslint-config-prettier/blob/master/index.js)
- [`prettier/babel`](https://github.com/prettier/eslint-config-prettier/blob/master/babel.js)
- [`prettier/react`](https://github.com/prettier/eslint-config-prettier/blob/master/react.js)