### PR TITLE
docs: mention the typescript parser and plugin as dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ for it.
 - `webpack`: [Webpack](https://npmjs.com/package/webpack) for the import plugin
   to work with webpack overloaded imports/requires (_eslint-plugin-import_ and
   _eslint-import-resolver-webpack_)
+- `@typescript-eslint`:
+  [@typescript-eslint/parser](https://www.npmjs.com/package/@typescript-eslint/parser)
+  and [@typescript-eslint/eslint-plugin](https://www.npmjs.com/package/@typescript-eslint/eslint-plugin).
 
 ### Things to know
 


### PR DESCRIPTION
Closes https://github.com/kentcdodds/eslint-config-kentcdodds/issues/100.

Mention the typescript eslint parser and plugin as dependencies for the typescript rules.