### PR TITLE
fix: use `@rushstack/eslint-patch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,22 +78,6 @@ module.exports = {
 }
 ```
 
-**Note**: Due to [this bug](https://github.com/eslint/eslint/issues/3458) you
-need to have the associated plugins installed to make things work. I recommend
-adding them as dependencies to your project if you're going to use the config
-for it.
-
-- `jest`: [jest](http://facebook.github.io/jest/) testing framework
-- `jsx-a11y`:
-  [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y)
-  for rules regarding accessibility with JSX (_eslint-plugin-jsx-a11y_)
-- `react`: [React](https://www.npmjs.com/package/react) JS library
-  (_eslint-plugin-react_)
-- `@typescript-eslint`:
-  [@typescript-eslint/parser](https://www.npmjs.com/package/@typescript-eslint/parser)
-  and
-  [@typescript-eslint/eslint-plugin](https://www.npmjs.com/package/@typescript-eslint/eslint-plugin).
-
 ### Things to know
 
 - All plugins needed for rules used by these configs are dependencies of this

--- a/import.js
+++ b/import.js
@@ -1,3 +1,9 @@
+/**
+ * @see https://github.com/eslint/eslint/issues/3458
+ * @see https://www.npmjs.com/package/@rushstack/eslint-patch
+ */
+require('@rushstack/eslint-patch/modern-module-resolution')
+
 module.exports = {
   env: {
     es6: true,

--- a/index.js
+++ b/index.js
@@ -1,6 +1,12 @@
 const fs = require('fs')
 const path = require('path')
 
+/**
+ * @see https://github.com/eslint/eslint/issues/3458
+ * @see https://www.npmjs.com/package/@rushstack/eslint-patch
+ */
+require('@rushstack/eslint-patch/modern-module-resolution')
+
 const tsConfig = fs.existsSync('tsconfig.json')
   ? path.resolve('tsconfig.json')
   : fs.existsSync('types/tsconfig.json')

--- a/jest.js
+++ b/jest.js
@@ -1,5 +1,11 @@
 const readPkgUp = require('read-pkg-up')
 
+/**
+ * @see https://github.com/eslint/eslint/issues/3458
+ * @see https://www.npmjs.com/package/@rushstack/eslint-patch
+ */
+require('@rushstack/eslint-patch/modern-module-resolution')
+
 let hasJestDom = false
 let hasTestingLibrary = false
 

--- a/jsx-a11y.js
+++ b/jsx-a11y.js
@@ -1,3 +1,9 @@
+/**
+ * @see https://github.com/eslint/eslint/issues/3458
+ * @see https://www.npmjs.com/package/@rushstack/eslint-patch
+ */
+require('@rushstack/eslint-patch/modern-module-resolution')
+
 module.exports = {
   env: {
     browser: true,

--- a/package.json
+++ b/package.json
@@ -2,6 +2,24 @@
   "name": "eslint-config-kentcdodds",
   "version": "0.0.0-semantically-released",
   "description": "ESLint rules according to kentcdodds' personal preference",
+  "keywords": [
+    "eslint",
+    "eslintconfig",
+    "config",
+    "kentcdodds",
+    "javascript",
+    "styleguide"
+  ],
+  "homepage": "https://github.com/kentcdodds/eslint-config-kentcdodds#readme",
+  "bugs": {
+    "url": "https://github.com/kentcdodds/eslint-config-kentcdodds/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kentcdodds/eslint-config-kentcdodds"
+  },
+  "license": "MIT",
+  "author": "Kent C. Dodds <me@kentcdodds.com> (https://kentcdodds.com)",
   "main": "index.js",
   "scripts": {
     "find-new-rules": "npm-run-all --parallel find-new-rules:*",
@@ -14,25 +32,16 @@
     "test": "npm-run-all --parallel lint find-new-rules",
     "validate": "npm-run-all --parallel lint test"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/kentcdodds/eslint-config-kentcdodds"
+  "eslintConfig": {
+    "extends": "./index.js"
   },
-  "keywords": [
-    "eslint",
-    "eslintconfig",
-    "config",
-    "kentcdodds",
-    "javascript",
-    "styleguide"
+  "eslintIgnore": [
+    "node_modules",
+    "coverage",
+    "dist"
   ],
-  "author": "Kent C. Dodds <me@kentcdodds.com> (https://kentcdodds.com)",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/kentcdodds/eslint-config-kentcdodds/issues"
-  },
-  "homepage": "https://github.com/kentcdodds/eslint-config-kentcdodds#readme",
   "dependencies": {
+    "@rushstack/eslint-patch": "^1.1.3",
     "@typescript-eslint/eslint-plugin": "^5.27.1",
     "@typescript-eslint/parser": "^5.27.1",
     "eslint-config-prettier": "^8.5.0",
@@ -68,14 +77,6 @@
       "optional": true
     }
   },
-  "eslintConfig": {
-    "extends": "./index.js"
-  },
-  "eslintIgnore": [
-    "node_modules",
-    "coverage",
-    "dist"
-  ],
   "engines": {
     "node": "^12.22.0 || ^14.17.0 || >=16.0.0",
     "npm": ">=6",

--- a/react.js
+++ b/react.js
@@ -1,6 +1,12 @@
 const readPkgUp = require('read-pkg-up')
 const semver = require('semver')
 
+/**
+ * @see https://github.com/eslint/eslint/issues/3458
+ * @see https://www.npmjs.com/package/@rushstack/eslint-patch
+ */
+require('@rushstack/eslint-patch/modern-module-resolution')
+
 let oldestSupportedReactVersion = '16.5.2'
 
 let hasPropTypes = false


### PR DESCRIPTION
Don't know why we didn't do this faster, as we do this in the Remix config, CRA does this too, ...

---

I also ran `npx sort-package-json`, so that's why some things moved in `package.json` as well